### PR TITLE
rest 및 jwt 적용 완료 (#12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,5 @@ out/
 .vscode/
 
 ### CUSTOM ###
-application-secret.yml
 medium_dev.mv.db
 medium_dev.trace.db

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+## url : https://medium.hyojunkim.site/
+
 # 할일
 
 ## 회원
@@ -9,7 +11,7 @@
 - [x] test data insert
 - [x] 유료 멤버십 기능
 - [x] 검색 필터링, 정렬
-- [x] 카카오 로그인
+- [x] 카카오 로그인(배포판 client id 문제로 현재 불가능)
 
 ## 무중단 배포
 - [x] 배포(젠킨스)

--- a/src/main/java/com/ll/medium/domain/member/member/controller/ApiV1MembersController.java
+++ b/src/main/java/com/ll/medium/domain/member/member/controller/ApiV1MembersController.java
@@ -1,0 +1,87 @@
+package com.ll.medium.domain.member.member.controller;
+
+import com.ll.medium.domain.member.member.dto.MemberDto;
+import com.ll.medium.domain.member.member.entity.Member;
+import com.ll.medium.domain.member.member.service.MemberService;
+import com.ll.medium.global.rq.Rq.Rq;
+import com.ll.medium.global.rsData.RsData.RsData;
+import com.ll.medium.global.util.jwt.JwtService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class ApiV1MembersController {
+    private final MemberService memberService;
+    private final Rq rq;
+    private final JwtService JwtService;
+
+    @Getter
+    @Setter
+    public static class LoginRequestBody {
+        private String username;
+        private String password;
+
+    }
+    @Getter
+    public static class LoginResponseBody {
+        private final MemberDto result;
+
+        public LoginResponseBody(Member member) {
+            result = new MemberDto(member);
+        }
+
+    }
+
+    @PostMapping("/login")
+    public RsData<LoginResponseBody> login(@RequestBody LoginRequestBody requestBody) {
+        RsData<Member> rsData = memberService.checkUsernameAndPassword(requestBody.getUsername(), requestBody.getPassword());
+        Member member = rsData.getData();
+        Long id = member.getId();
+        String accessToken = JwtService.encode(
+                Map.of(
+                        "id", id.toString(),
+                        "username", member.getUsername(),
+                        "authorities", member.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(toList())
+                ),
+                (long) 1000 * 60 * 10  // 10분짜리 엑세스 토큰
+        );
+        String refreshToken = JwtService.encode(
+                Map.of(
+                        "id", id.toString(),
+                        "username", member.getUsername()
+
+                ),
+                (long) 1000 * 60 * 60 * 24 * 365
+        );
+        rq.setCrossDomainCookie("accessToken", accessToken);
+        rq.setCrossDomainCookie("refreshToken", refreshToken);
+
+        memberService.setRefreshToken(member, refreshToken);
+        return rsData.of(new LoginResponseBody(member));
+    }
+    @Getter
+    @Setter
+    public static class RefreshAccessTokenRequestBody {
+        private String refreshToken;
+    }
+    @Getter
+    public static class RefreshAccessTokenResponseBody {
+        private final String accessToken;
+        public RefreshAccessTokenResponseBody(String accessToken) {
+            this.accessToken = accessToken;
+        }
+    }
+
+}

--- a/src/main/java/com/ll/medium/domain/member/member/dto/MemberDto.java
+++ b/src/main/java/com/ll/medium/domain/member/member/dto/MemberDto.java
@@ -1,0 +1,24 @@
+package com.ll.medium.domain.member.member.dto;
+
+import com.ll.medium.domain.member.member.entity.Member;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MemberDto {
+    private final Long id;
+    private final String username;
+    private final String nickname;
+    private final LocalDateTime createDate;
+    private final LocalDateTime modifyDate;
+
+    public MemberDto(Member member) {
+        this.id = member.getId();
+        this.createDate = member.getCreateDate();
+        this.modifyDate = member.getModifyDate();
+        this.username = member.getUsername();
+        this.nickname = member.getNickname();
+    }
+
+}

--- a/src/main/java/com/ll/medium/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/medium/domain/member/member/entity/Member.java
@@ -1,53 +1,39 @@
 package com.ll.medium.domain.member.member.entity;
 
+import com.ll.medium.global.jpa.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
-@NoArgsConstructor(access = PROTECTED)
+@SuperBuilder
 @AllArgsConstructor(access = PROTECTED)
-@Builder
+@NoArgsConstructor(access = PROTECTED)
 @Getter
 @Setter
-@EntityListeners(AuditingEntityListener.class)
-public class Member {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-
-    @CreatedDate
-    private LocalDateTime createDate;
-
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
-
+@ToString(callSuper = true)
+public class Member extends BaseEntity {
     private String username;
-
     private String password;
-
     private boolean isPaid;
-
     private String nickname;
+    private String refreshToken;
 
 
 
 
+    public String getName() {
+        return this.nickname != null ? this.nickname : this.username;
+    }
+    @SuppressWarnings("JpaAttributeTypeInspection")
     public Collection<? extends GrantedAuthority> getAuthorities() {
         List<GrantedAuthority> authorities = new ArrayList<>();
 

--- a/src/main/java/com/ll/medium/domain/member/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/medium/domain/member/member/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/ll/medium/domain/post/post/controller/ApiV1PostsController.java
+++ b/src/main/java/com/ll/medium/domain/post/post/controller/ApiV1PostsController.java
@@ -1,0 +1,126 @@
+package com.ll.medium.domain.post.post.controller;
+
+import com.ll.medium.domain.member.member.entity.Member;
+import com.ll.medium.domain.member.member.service.MemberService;
+import com.ll.medium.domain.post.post.dto.PostDto;
+import com.ll.medium.domain.post.post.entity.Post;
+import com.ll.medium.domain.post.post.service.PostService;
+import com.ll.medium.global.rq.Rq.Rq;
+import com.ll.medium.global.rsData.RsData.RsData;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+//메서드에 @ResponsBody자동으로 붙는다
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+public class ApiV1PostsController {
+    private final PostService postService;
+    private final Rq rq;
+    private final MemberService memberService;
+    @Getter
+    public static class GetPostsResponseBody{
+        private final List<PostDto> result;
+        private final Map pagination;
+        public GetPostsResponseBody(List<Post> posts) {
+            result = posts.stream()
+                    .map(PostDto::new)
+                    .toList();
+
+            pagination = Map.of("page", 1);
+        }
+    }
+
+    @GetMapping("")
+    public RsData<GetPostsResponseBody> getPosts(){
+        return RsData.of("200", "success", new GetPostsResponseBody(postService.findAllByOrderByIdDesc()));
+    }
+    @Getter
+    public static class GetPostResponseBody{
+        private final PostDto result;
+        public GetPostResponseBody(Post post) {
+            result = new PostDto(post);
+        }
+    }
+    @GetMapping("/{id}")
+    public RsData<GetPostResponseBody> getPost(@PathVariable Long id){
+        return RsData.of("200", "success", new GetPostResponseBody(postService.findById(id).get()));
+    }
+
+    @Getter
+    public static class DeletePostResponseBody{
+        private final PostDto result;
+        public DeletePostResponseBody(Post post) {
+            result = new PostDto(post);
+        }
+    }
+    @DeleteMapping("/{id}")
+    public RsData<DeletePostResponseBody> deletePost(@PathVariable Long id){
+        RsData<Post> rsData = postService.deletePost(id);
+        return RsData.of(
+                rsData.getResultCode(),
+                rsData.getMsg(),
+                new DeletePostResponseBody(
+                        rsData.getData()
+                )
+        );
+    }
+    @Getter
+    @Setter
+    public static class UpdatePostRequestBody{
+        private String title;
+        private String body;
+    }
+
+    @Getter
+    public static class UpdatePostResponseBody{
+        private final PostDto result;
+        public UpdatePostResponseBody(Post post) {
+            result = new PostDto(post);
+        }
+    }
+    @PutMapping("/{id}")
+    public RsData<UpdatePostResponseBody> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequestBody body){
+        Post post = postService.findById(id).get();
+        RsData<Post> rsData = postService.updatePost(post, body.getTitle(), body.getBody());
+
+        return RsData.of(rsData.getResultCode(), rsData.getMsg(), new UpdatePostResponseBody(rsData.getData()));
+    }
+    @Getter
+    @Setter
+    public static class WritePostRequestBody{
+        private String title;
+        private String body;
+    }
+
+    @Getter
+    public static class WritePostResponseBody{
+        private final PostDto result;
+        public WritePostResponseBody(Post post) {
+            result = new PostDto(post);
+        }
+    }
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("")
+    public RsData<WritePostResponseBody> writePost(@RequestBody WritePostRequestBody body){
+        Member member = rq.getAuthenticatedMemberFromSecurityContext();
+        RsData<Post> rsData= postService.writePost(member, body.getTitle(), body.getBody());
+
+        return rsData.of(
+                new WritePostResponseBody(rsData.getData())
+        );
+    }
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/my")
+    public RsData<GetPostsResponseBody> getMyPosts(){
+        Member member = rq.getAuthenticatedMemberFromSecurityContext();
+        return RsData.of("200", "success", new GetPostsResponseBody(postService.findbyAuthor(member)));
+    }
+
+}

--- a/src/main/java/com/ll/medium/domain/post/post/dto/PostDto.java
+++ b/src/main/java/com/ll/medium/domain/post/post/dto/PostDto.java
@@ -1,0 +1,28 @@
+package com.ll.medium.domain.post.post.dto;
+
+import com.ll.medium.domain.post.post.entity.Post;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PostDto {
+    private final Long id;
+    private final LocalDateTime createDate;
+    private final LocalDateTime modifyDate;
+    private final Long authorId;
+    private final String authorName;
+    private final String title;
+    private final String body;
+
+    public PostDto(Post post){
+        this.id = post.getId();
+        this.createDate = post.getCreateDate();
+        this.modifyDate = post.getModifyDate();
+        this.authorId = post.getAuthor().getId();
+        this.authorName = post.getAuthor().getName();
+        this.title = post.getTitle();
+        this.body = post.getBody();
+    }
+
+}

--- a/src/main/java/com/ll/medium/domain/post/post/entity/Post.java
+++ b/src/main/java/com/ll/medium/domain/post/post/entity/Post.java
@@ -1,35 +1,26 @@
 package com.ll.medium.domain.post.post.entity;
 
 import com.ll.medium.domain.member.member.entity.Member;
-import jakarta.persistence.*;
+import com.ll.medium.global.jpa.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
-
-import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
-@NoArgsConstructor(access = PROTECTED)
+@SuperBuilder
 @AllArgsConstructor(access = PROTECTED)
-@Builder
+@NoArgsConstructor(access = PROTECTED)
 @Getter
 @Setter
-@EntityListeners(AuditingEntityListener.class)
-public class Post {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
+@ToString(callSuper = true)
+public class Post extends BaseEntity {
 
-    @CreatedDate
-    private LocalDateTime createDate;
-
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
-
+    //fetch = lazy라는건 Member가 프록시라는 의미
     @ManyToOne(fetch = FetchType.LAZY)
     private Member author;
 

--- a/src/main/java/com/ll/medium/domain/post/post/repository/PostRepository.java
+++ b/src/main/java/com/ll/medium/domain/post/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.ll.medium.domain.post.post.repository;
 
+import com.ll.medium.domain.member.member.entity.Member;
 import com.ll.medium.domain.post.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     Page<Post> findByTitleContainingIgnoreCaseOrBodyContainingIgnoreCase(String kw, String kw_, Pageable pageable);
 
+    List<Post> findAllByOrderByIdDesc();
+
+    List<Post> findByAuthor(Member member);
 }

--- a/src/main/java/com/ll/medium/domain/post/post/service/PostService.java
+++ b/src/main/java/com/ll/medium/domain/post/post/service/PostService.java
@@ -3,21 +3,24 @@ package com.ll.medium.domain.post.post.service;
 import com.ll.medium.domain.member.member.entity.Member;
 import com.ll.medium.domain.post.post.entity.Post;
 import com.ll.medium.domain.post.post.repository.PostRepository;
+import com.ll.medium.global.rsData.RsData.RsData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostService {
     private final PostRepository postRepository;
 
-
-    public void write(Member author, String title, String body, boolean isPublished, boolean isPaid) {
+    @Transactional
+    public RsData<Post> write(Member author, String title, String body, boolean isPublished, boolean isPaid) {
         Post post = Post.builder()
                 .author(author)
                 .title(title)
@@ -29,6 +32,7 @@ public class PostService {
                 .build();
 
         postRepository.save(post);
+        return RsData.of("200","%d번 게시글이 작성되었습니다.".formatted(post.getId()), post);
     }
 
     public Object findTop30ByIsPublishedOrderByIdDesc(boolean isPublished) {
@@ -64,5 +68,49 @@ public class PostService {
 
     }
 
+    public List<Post> findAll() {
+        return postRepository.findAll();
+    }
 
+    public List<Post> findAllByOrderByIdDesc() {
+        return postRepository.findAllByOrderByIdDesc();
+    }
+
+    @Transactional
+    public RsData<Post> deletePost(long id) {
+        Post post = postRepository.findById(id).get();
+        postRepository.deleteById(id);
+
+        return RsData.of("200","%d번 게시글이 삭제 되었습니다.".formatted(id), post);
+
+    }
+
+    @Transactional
+    public RsData<Post> updatePost(Post post, String title, String body) {
+        post.setTitle(title);
+        post.setBody(body);
+        //더티 체킹으로 생략 가능
+        //postRepository.save(post);
+        return RsData.of("200","%d번 게시글이 수정 되었습니다.".formatted(post.getId()), post);
+    }
+
+    @Transactional
+    public RsData<Post> writePost(Member member, String title, String body) {
+        Post post = Post.builder()
+                .author(member)
+                .title(title)
+                .body(body)
+                .isPublished(true)
+                .isPaid(false)
+                .hitCount(0L)
+                .likeCount(0L)
+                .build();
+
+        postRepository.save(post);
+        return RsData.of("200","%d번 게시글이 작성되었습니다.".formatted(post.getId()), post);
+    }
+
+    public List<Post> findbyAuthor(Member member) {
+        return postRepository.findByAuthor(member);
+    }
 }

--- a/src/main/java/com/ll/medium/global/app/AppConfig.java
+++ b/src/main/java/com/ll/medium/global/app/AppConfig.java
@@ -23,6 +23,9 @@ public class AppConfig {
     @Getter
     public static String siteBaseUrl;
 
+    @Getter
+    public static String jwtSecretKey;
+
     @Value("${custom.tempDirPath}")
     public void setTempDirPath(String tempDirPath) {
         AppConfig.tempDirPath = tempDirPath;
@@ -54,5 +57,9 @@ public class AppConfig {
         }
 
         return resourcesStaticDirPath;
+    }
+    @Value("${custom.jwt.secretKey}")
+    public void setJwtSecretKey(String jwtSecretKey) {
+        AppConfig.jwtSecretKey = jwtSecretKey;
     }
 }

--- a/src/main/java/com/ll/medium/global/auth/CustomUser.java
+++ b/src/main/java/com/ll/medium/global/auth/CustomUser.java
@@ -1,6 +1,6 @@
 package com.ll.medium.global.auth;
 
-import com.ll.medium.domain.member.member.entity.Member;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -8,35 +8,52 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import java.util.Collection;
 import java.util.Map;
 
+//User 클래스는 UserDetails를 구현한 대표적인 클래스 중 하나
+//CustomUser는 UserDetails를 구현한 커스텀 클래스
 //Authentication 객체에 저장할수있는 유일한 타입
-public class CustomUserDetails implements UserDetails, OAuth2User {
+public class CustomUser implements UserDetails, OAuth2User {
 
-    private Member member;
+    @Getter
+    private long id;
+    private final String username;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
     private Map<String, Object> attributes;
 
     //일반로그인시 사용
-    public CustomUserDetails(Member member){
-        this.member=member;
+    public CustomUser(long id, String username, String password, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.authorities = authorities;
     }
+
     //OAuth2 로그인시 사용
-    public CustomUserDetails(Member member, Map<String, Object> attributes){
-        this.member = member;
+    public CustomUser(long id, String username, String password, Collection<? extends GrantedAuthority> authorities,Map<String, Object> attributes){
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.authorities = authorities;
         this.attributes = attributes;
     }
+
+
+
     //UserDetails구현 시작
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return member.getAuthorities();
+        return this.authorities;
     }
 
     @Override
     public String getPassword() {
-        return member.getPassword();
+        return this.password;
     }
 
     @Override
     public String getUsername() {
-        return member.getUsername();
+        return this.username;
     }
 
     @Override
@@ -64,14 +81,16 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
     // 리소스 서버로 부터 받는 회원정보
     @Override
     public Map<String, Object> getAttributes() {
-        return attributes;
+        return this.attributes;
+    }
+
+    @Override
+    public String getName() {
+        return this.username;
     }
 
     // User의 PrimaryKey
-    @Override
-    public String getName() {
-        return member.getId()+"";
-    }
+
     //OAuth2User구현 끝
 
 }

--- a/src/main/java/com/ll/medium/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/ll/medium/global/auth/CustomUserDetailsService.java
@@ -28,13 +28,13 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         Member member = opMember.get();
 
-        //CustomUserDetails객체로 회원가입 회원과 소셜회원 로그인 통합
-        return new CustomUserDetails(member);
-//        return new User(
-//                member.getUsername(),
-//                member.getPassword(),
-//                member.getAuthorities()
-//        );
+        //CustomUser 객체로 회원가입 회원과 소셜회원 로그인 통합
+        return new CustomUser(
+                member.getId(),
+                member.getUsername(),
+                member.getPassword(),
+                member.getAuthorities()
+        );
 
     }
 }

--- a/src/main/java/com/ll/medium/global/init/NotProd.java
+++ b/src/main/java/com/ll/medium/global/init/NotProd.java
@@ -3,11 +3,14 @@ package com.ll.medium.global.init;
 import com.ll.medium.domain.member.member.entity.Member;
 import com.ll.medium.domain.member.member.service.MemberService;
 import com.ll.medium.domain.post.post.service.PostService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 
@@ -18,6 +21,9 @@ import java.util.stream.IntStream;
 @Slf4j
 @RequiredArgsConstructor
 public class NotProd {
+    @Autowired
+    @Lazy
+    private NotProd self;
     private final MemberService memberService;
     private final PostService postService;
 
@@ -25,25 +31,30 @@ public class NotProd {
     @Order(3)
     public ApplicationRunner initNotProd() {
         return args -> {
-            // 이미 회원이 존재하는 경우 초기화를 수행하지 않음
-            if (memberService.findByUsername("user1").isPresent()) return;
-
-            // 유료멤버십 회원 생성
-            IntStream.rangeClosed(1, 100).forEach(i -> {
-                boolean isPaidMember = i % 2 == 0; // 홀수는 유료, 짝수는 무료
-                memberService.join("user" + i, "123", isPaidMember);
-            });
-
-            // 유료글 생성
-            IntStream.rangeClosed(1, 100).forEach(i -> {
-                Member member = memberService.findByUsername("user" + i).orElseThrow();
-
-                boolean isPaidPost = i % 2 == 0; // 홀수는 유료, 짝수는 무료
-                boolean isPublished = i % 3 != 0; // 1/3의 확률로 공개글
-                postService.write(member, "제목 " + i, "내용 " + i,  isPublished, isPaidPost);
-            });
+           self.work1();
         };
 
 
     }
+    @Transactional
+    public void work1(){
+        // 이미 회원이 존재하는 경우 초기화를 수행하지 않음
+        if (memberService.findByUsername("user1").isPresent()) return;
+
+        // 유료멤버십 회원 생성
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            boolean isPaidMember = i % 2 == 0; // 홀수는 유료, 짝수는 무료
+            memberService.join("user" + i, "123", isPaidMember);
+        });
+
+        // 유료글 생성
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            Member member = memberService.findByUsername("user" + i).orElseThrow();
+
+            boolean isPaidPost = i % 2 == 0; // 홀수는 유료, 짝수는 무료
+            boolean isPublished = i % 3 != 0; // 1/3의 확률로 공개글
+            postService.write(member, "제목 " + i, "내용 " + i,  isPublished, isPaidPost);
+        });
+    }
+
 }

--- a/src/main/java/com/ll/medium/global/init/Prod.java
+++ b/src/main/java/com/ll/medium/global/init/Prod.java
@@ -3,11 +3,14 @@ package com.ll.medium.global.init;
 import com.ll.medium.domain.member.member.entity.Member;
 import com.ll.medium.domain.member.member.service.MemberService;
 import com.ll.medium.domain.post.post.service.PostService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 
@@ -19,6 +22,9 @@ import java.util.stream.IntStream;
 @Profile("prod")
 @RequiredArgsConstructor
 public class Prod {
+    @Autowired
+    @Lazy
+    private Prod self;
     private final MemberService memberService;
     private final PostService postService;
 
@@ -26,25 +32,32 @@ public class Prod {
     @Order(3)
     public ApplicationRunner initNotProd() {
         return args -> {
-            // 이미 회원이 존재하는 경우 초기화를 수행하지 않음
-            if (memberService.findByUsername("user1").isPresent()) return;
-
-            // 유료멤버십 회원 생성
-            IntStream.rangeClosed(1, 100).forEach(i -> {
-                boolean isPaidMember = i % 2 == 0; // 홀수는 유료, 짝수는 무료
-                memberService.join("user" + i, "123", isPaidMember);
-            });
-
-            // 유료글 생성
-            IntStream.rangeClosed(1, 100).forEach(i -> {
-                Member member = memberService.findByUsername("user" + i).orElseThrow();
-
-                boolean isPaidPost = i % 2 == 0; // 홀수는 유료, 짝수는 무료
-                boolean isPublished = i % 3 != 0; // 1/3의 확률로 공개글
-                postService.write(member, "제목 " + i, "내용 " + i,  isPublished, isPaidPost);
-            });
+           self.work2();
         };
 
 
     }
+    
+    @Transactional
+    public void work2() {
+        // 이미 회원이 존재하는 경우 초기화를 수행하지 않음
+        if (memberService.findByUsername("user1").isPresent()) return;
+
+        // 유료멤버십 회원 생성
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            boolean isPaidMember = i % 2 == 0; // 홀수는 유료, 짝수는 무료
+            memberService.join("user" + i, "123", isPaidMember);
+        });
+
+        // 유료글 생성
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            Member member = memberService.findByUsername("user" + i).orElseThrow();
+
+            boolean isPaidPost = i % 2 == 0; // 홀수는 유료, 짝수는 무료
+            boolean isPublished = i % 3 != 0; // 1/3의 확률로 공개글
+            postService.write(member, "제목 " + i, "내용 " + i,  isPublished, isPaidPost);
+        });
+    }
+
+
 }

--- a/src/main/java/com/ll/medium/global/jpa/BaseEntity.java
+++ b/src/main/java/com/ll/medium/global/jpa/BaseEntity.java
@@ -1,0 +1,34 @@
+package com.ll.medium.global.jpa;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+@SuperBuilder
+@Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+    @CreatedDate
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    @Setter
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/com/ll/medium/global/jpa/JpaConfig.java
+++ b/src/main/java/com/ll/medium/global/jpa/JpaConfig.java
@@ -10,10 +10,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class JpaConfig {
     @PersistenceContext
-
-
     private EntityManager entityManager;
-
     @Bean
     public JPAQueryFactory jpaQueryFactory(){
         return new JPAQueryFactory(entityManager);

--- a/src/main/java/com/ll/medium/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/medium/global/oauth/CustomOAuth2UserService.java
@@ -4,7 +4,7 @@ import com.ll.medium.domain.member.member.entity.Member;
 import com.ll.medium.domain.member.member.repository.MemberRepository;
 import com.ll.medium.global.oauth.provider.KakaoUserInfo;
 import com.ll.medium.global.oauth.provider.OAuth2UserInfo;
-import com.ll.medium.global.auth.CustomUserDetails;
+import com.ll.medium.global.auth.CustomUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -69,8 +69,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new RuntimeException("해당 소셜로그인은 지원하지 않습니다.");
         }
 
-
-        return new CustomUserDetails(member, oAuth2User.getAttributes());
+        //소셜 로그인(세션)
+        return new CustomUser(member.getId(), member.getUsername(),member.getPassword(),member.getAuthorities(), oAuth2User.getAttributes());
     }
     public Member kakaoMemberJoin(String registrationId, OAuth2User oAuth2User, OAuth2UserInfo oAuth2UserInfo){
 

--- a/src/main/java/com/ll/medium/global/rq/Rq/Rq.java
+++ b/src/main/java/com/ll/medium/global/rq/Rq/Rq.java
@@ -2,19 +2,21 @@ package com.ll.medium.global.rq.Rq;
 
 import com.ll.medium.domain.member.member.entity.Member;
 import com.ll.medium.domain.member.member.service.MemberService;
-import com.ll.medium.global.auth.CustomUserDetails;
+import com.ll.medium.global.auth.CustomUser;
 import com.ll.medium.global.rsData.RsData.RsData;
 import com.ll.medium.standard.util.Ut.Ut;
+import jakarta.persistence.EntityManager;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
-
+import jakarta.servlet.http.Cookie;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -27,6 +29,10 @@ public class Rq {
     private final HttpServletRequest request;
     private final HttpServletResponse response;
     private final MemberService memberService;
+    private Member member;
+    private final EntityManager entityManager;
+    private CustomUser customUser;
+
 
     public String redirect(String url, String msg) {
         if(msg == null){
@@ -55,44 +61,23 @@ public class Rq {
         return redirect(path, rs.getMsg());
     }
 
-    public User getUser() {
-        return Optional.ofNullable(SecurityContextHolder.getContext())
-                .map(SecurityContext::getAuthentication)
-                .map(Authentication::getPrincipal)
-                .filter(it -> it instanceof User)
-                .map(it -> (User) it)
-                .orElse(null);
-    }
-    public CustomUserDetails getCurrentUser() {
-        return Optional.ofNullable(SecurityContextHolder.getContext())
-                .map(SecurityContext::getAuthentication)
-                .filter(authentication -> authentication.getPrincipal() instanceof CustomUserDetails)
-                .map(authentication -> (CustomUserDetails) authentication.getPrincipal())
-                .orElse(null);
+    public CustomUser getCustomUser() {
+        if (customUser == null) {
+            customUser = Optional.ofNullable(SecurityContextHolder.getContext())
+                    .map(SecurityContext::getAuthentication)
+                    .filter(authentication -> authentication.getPrincipal() instanceof CustomUser)
+                    .map(authentication -> (CustomUser) authentication.getPrincipal())
+                    .orElse(null);
+        }
+        return customUser;
     }
 
     public boolean isLogin() {
-        return getCurrentUser() != null;
+        return getCustomUser() != null;
     }
 
     public boolean isLogout() {
         return !isLogin();
-    }
-
-    public boolean isAdmin() {
-        if (isLogout()) return false;
-
-        return getUser()
-                .getAuthorities()
-                .stream()
-                .anyMatch(it -> it.getAuthority().equals("ROLE_ADMIN"));
-    }
-    public boolean isPaid() {
-        if(isLogout())return false;
-        return getUser()
-                .getAuthorities()
-                .stream()
-                .anyMatch(it -> it.getAuthority().equals("ROLE_PAID"));
     }
 
     public void setAttribute(String key, Object value) {
@@ -115,7 +100,133 @@ public class Rq {
     public Member getLoginedMember(){
         if (isLogout())
             return null;
-        Member member = memberService.findByUsername(this.getCurrentUser().getUsername()).get();
+        Member member = memberService.findByUsername(this.getCustomUser().getUsername()).get();
         return member;
+    }
+
+    public Member getAuthenticatedMemberFromSecurityContext(){
+        if (isLogout())
+            throw new RuntimeException("rq : 로그인이 필요합니다. 로그인 후 다시 시도해주세요.");
+        if(member == null)
+            member = entityManager.getReference(Member.class, getCustomUser().getId());
+        return member;
+    }
+    public boolean isAdmin(){
+        if(isLogout())
+            return false;
+        return getCustomUser()
+                .getAuthorities()
+                .stream()
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+    }
+    public boolean isPaid(){
+        if(isLogout())
+            return false;
+        return getCustomUser()
+                .getAuthorities()
+                .stream()
+                .anyMatch(it -> it.getAuthority().equals("ROLE_PAID"));
+    }
+
+    public void setAuthentication(CustomUser user) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                user,
+                user.getPassword(),
+                user.getAuthorities()
+        );
+        // 스프링 시큐리티 세션에 해당 객체 저장해서 로그인 처리
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    public String getHeader(String name, String defaultValue) {
+        String value = request.getHeader(name);
+
+        if (value == null) {
+            return defaultValue;
+        }
+
+        return value;
+    }
+
+    // 일반
+    public boolean isAjax() {
+        if ("application/json".equals(request.getHeader("Accept"))) return true;
+        return "XMLHttpRequest".equals(request.getHeader("X-Requested-With"));
+    }
+
+    // 쿠키 관련
+    public void setCookie(String name, String value) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+
+    public void setCrossDomainCookie(String name, String value) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")
+                .sameSite("None")
+                .secure(true)
+                .httpOnly(true)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public Cookie getCookie(String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return null;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(name)) {
+                return cookie;
+            }
+        }
+
+        return null;
+    }
+
+    public String getCookieValue(String name, String defaultValue) {
+        Cookie cookie = getCookie(name);
+
+        if (cookie == null) {
+            return defaultValue;
+        }
+
+        return cookie.getValue();
+    }
+
+    private long getCookieAsLong(String name, int defaultValue) {
+        String value = getCookieValue(name, null);
+
+        if (value == null) {
+            return defaultValue;
+        }
+
+        return Long.parseLong(value);
+    }
+
+    public void removeCookie(String name) {
+        Cookie cookie = getCookie(name);
+
+        if (cookie == null) {
+            return;
+        }
+
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+
+        ResponseCookie responseCookie = ResponseCookie.from(name, null)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .secure(true)
+                .httpOnly(true)
+                .build();
+
+        response.addHeader("Set-Cookie", responseCookie.toString());
     }
 }

--- a/src/main/java/com/ll/medium/global/rsData/RsData/RsData.java
+++ b/src/main/java/com/ll/medium/global/rsData/RsData/RsData.java
@@ -1,29 +1,34 @@
 package com.ll.medium.global.rsData.RsData;
 
+
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-import static lombok.AccessLevel.PRIVATE;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = PRIVATE)
+// AccessLevel.PROTECTED는 해당 클래스 내부와 해당 클래스를 상속하는 클래스에서만 생성자를 사용할 수 있다
+// of메서드를 통해서만 사용하도록 권장
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class RsData<T> {
-    String resultCode;
-    int statusCode;
-    String msg;
-    T data;
+    private final String resultCode;
+    private final String msg;
+    private final T data;
+    private final int statusCode;
+
+    public static <T> RsData<T> of(String resultCode, String msg, T data) {
+        int statusCode = Integer.parseInt(resultCode.split("-", 2)[0]);
+        return new RsData<>(resultCode, msg, data, statusCode);
+    }
 
     public static <T> RsData<T> of(String resultCode, String msg) {
         return of(resultCode, msg, null);
     }
-
-    public static <T> RsData<T> of(String resultCode, String msg, T data) {
-        int statusCode = Integer.parseInt(resultCode.split("-", 2)[0]);
-
-        return new RsData<>(resultCode, statusCode, msg, data);
+    public <T> RsData<T> of(T data) {
+        return RsData.of(resultCode, msg, data);
     }
+
+
 
     public boolean isSuccess() {
         return getStatusCode() >= 200 && getStatusCode() < 400;
@@ -32,4 +37,6 @@ public class RsData<T> {
     public boolean isFail() {
         return !isSuccess();
     }
+
+
 }

--- a/src/main/java/com/ll/medium/global/security/ApiSecurityConfig.java
+++ b/src/main/java/com/ll/medium/global/security/ApiSecurityConfig.java
@@ -1,0 +1,29 @@
+package com.ll.medium.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class ApiSecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    @Bean
+    public SecurityFilterChain apiFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .securityMatcher("/api/**")
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors
+                        .configure(httpSecurity)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return httpSecurity.build();
+    }
+}

--- a/src/main/java/com/ll/medium/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ll/medium/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.ll.medium.global.security;
+
+import com.ll.medium.domain.member.member.service.MemberService;
+import com.ll.medium.global.auth.CustomUser;
+import com.ll.medium.global.rq.Rq.Rq;
+import com.ll.medium.global.rsData.RsData.RsData;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final MemberService memberService;
+    private final Rq rq;
+
+    @Override
+    @SneakyThrows
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+        //로그인과 로그아웃일때는 필터링 하지 않음
+        if(request.getRequestURI().equals("/api/v1/members/login") || request.getRequestURI().equals("/api/v1/members/logout")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String accessToken = rq.getCookieValue("accessToken", "");
+        String refreshToken = rq.getCookieValue("refreshToken", "");
+        if(!accessToken.isBlank()){
+            if(!memberService.validateAccessToken(accessToken)){
+                RsData<String> rs = memberService.refreshAccessToken(refreshToken);
+                accessToken = rs.getData();
+                rq.setCrossDomainCookie("accessToken", accessToken);
+            }
+            CustomUser user = memberService.getUserFromAccessToken(accessToken);
+            rq.setAuthentication(user);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/ll/medium/global/security/SecurityConfig.java
+++ b/src/main/java/com/ll/medium/global/security/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
         http
                 .authorizeRequests(authorizeRequests ->
                         authorizeRequests
+                                //먼저쓴것부터 적용된다
                                 .requestMatchers("/gen/**")
                                 .permitAll()
                                 .requestMatchers("/resource/**")
@@ -63,6 +64,7 @@ public class SecurityConfig {
                 .logout(
                         logout ->
                                 logout
+                                        //get요청도 로그아웃 가능
                                         .logoutRequestMatcher(new AntPathRequestMatcher("/member/logout"))
                 );
 

--- a/src/main/java/com/ll/medium/global/util/jwt/JwtService.java
+++ b/src/main/java/com/ll/medium/global/util/jwt/JwtService.java
@@ -1,0 +1,59 @@
+package com.ll.medium.global.util.jwt;
+
+import com.ll.medium.global.app.AppConfig;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Map;
+@Service
+public class JwtService {
+
+    public String encode(Map<String, Object> data, long expireTime) {
+        Claims claims = Jwts
+                .claims()
+                .setSubject("medium jwt token")
+                .add("data", data)
+                .build();
+
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expireTime); // 1초(1000)  1분(60)  1시간(60)  1일(24) * 7 = 7일
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(SignatureAlgorithm.HS256, AppConfig.getJwtSecretKey())
+                .compact();
+    }
+
+    public Claims decode(String token) {
+        return Jwts
+                .parser()
+                .setSigningKey(AppConfig.getJwtSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getPayload();
+
+
+    }
+    public boolean validateAccessToken(String token) {
+        try {
+            Claims claims = Jwts
+                    .parser()
+                    .setSigningKey(AppConfig.getJwtSecretKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            // 만료 시간 체크
+            if (claims.getExpiration().before(new Date())) {
+                return false; // 토큰이 만료됨
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/ll/medium/global/webMvc/CustomWebMvcConfig.java
+++ b/src/main/java/com/ll/medium/global/webMvc/CustomWebMvcConfig.java
@@ -12,6 +12,8 @@ public class CustomWebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
+                //프론트가 배포될거면 실제 사이트 적으면됨
+                //누가 들어올수있는지
                 .allowedOrigins("https://cdpn.io", "http://localhost:5173")
                 .allowedMethods("*")
                 .allowedHeaders("*")

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -1,0 +1,11 @@
+#추후 시크릿매니저 사용
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: e954f86bedb0cd880a2d01e100cb32d6
+custom:
+  jwt:
+    secretKey: abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,9 +1,12 @@
+#spring:
+#  datasource:
+#    url: jdbc:mysql://172.17.0.1:3306/medium_test
+#    username: root
+#    password: lldj123414
+#    driver-class-name: com.mysql.cj.jdbc.Driver
 spring:
   datasource:
-    url: jdbc:mysql://172.17.0.1:3306/medium_test
-    username: root
-    password: lldj123414
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:h2:mem:rest2023_test;MODE=MYSQL
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/test/java/com/ll/medium/domain/post/post/controller/ApiV1PostsControllerTest.java
+++ b/src/test/java/com/ll/medium/domain/post/post/controller/ApiV1PostsControllerTest.java
@@ -1,0 +1,175 @@
+package com.ll.medium.domain.post.post.controller;
+
+import com.ll.medium.domain.post.post.entity.Post;
+import com.ll.medium.domain.post.post.service.PostService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+// 스프링 컨텍스트(빈)을 로드해서 사용하기 위해서 필요하다.
+@SpringBootTest
+// MockMvc를 사용하기 위해서 필요하다.
+// MockMvc는 실제 웹 서버를 시작하지 않고도 스프링 MVC 컨트롤러를 테스트할 수 있게 해주는 클래스
+@AutoConfigureMockMvc
+@Transactional //롤백됨, 롤백 안하려면 테스트 메서드에 @Rollback(false)붙이기
+@ActiveProfiles("test")
+public class ApiV1PostsControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private PostService postService;
+    private static final String DATE_PATTERN = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.?\\d{0,7}";
+    @Test
+    @DisplayName("get /api/v1/posts")
+    void t1() throws Exception{
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/posts"))
+                        .andDo(print());
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1PostsController.class))
+                .andExpect(handler().methodName("getPosts"))
+                .andExpect(jsonPath("$.data.result[0].id", instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result[0].title", notNullValue()))
+                .andExpect(jsonPath("$.data.result[0].body", notNullValue()))
+                .andExpect(jsonPath("$.data.result[0].authorId",instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result[0].authorName", notNullValue()))
+                .andExpect(jsonPath("$.data.result[0].createDate", matchesPattern(DATE_PATTERN)))
+                .andExpect(jsonPath("$.data.result[0].modifyDate", matchesPattern(DATE_PATTERN)))
+                .andDo(print());
+    }
+    @Test
+    @DisplayName("get /api/v1/posts/{id}")
+    void t2() throws Exception{
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/posts/100"))
+                .andDo(print());
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1PostsController.class))
+                .andExpect(handler().methodName("getPost"))
+                .andExpect(jsonPath("$.data.result.id", instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.title", notNullValue()))
+                .andExpect(jsonPath("$.data.result.body", notNullValue()))
+                .andExpect(jsonPath("$.data.result.authorId",instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.authorName", notNullValue()))
+                .andExpect(jsonPath("$.data.result.createDate", matchesPattern(DATE_PATTERN)))
+                .andExpect(jsonPath("$.data.result.modifyDate", matchesPattern(DATE_PATTERN)))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("delete /api/v1/posts/{id}")
+    void t3() throws Exception{
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/posts/89"))
+                .andDo(print());
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1PostsController.class))
+                .andExpect(handler().methodName("deletePost"))
+                .andExpect(jsonPath("$.data.result.id", instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.title", notNullValue()))
+                .andExpect(jsonPath("$.data.result.body", notNullValue()))
+                .andExpect(jsonPath("$.data.result.authorId",instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.authorName", notNullValue()))
+                .andExpect(jsonPath("$.data.result.createDate", matchesPattern(DATE_PATTERN)))
+                .andExpect(jsonPath("$.data.result.modifyDate", matchesPattern(DATE_PATTERN)))
+                .andDo(print());
+
+        Post post = postService.findById(89L).orElse(null);
+        assertThat(post).isNull();
+
+    }
+    @Test
+    @DisplayName("put /api/v1/posts/{id}")
+    void t4() throws Exception{
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc
+                .perform(
+                        put("/api/v1/posts/99")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "title": "수정 제목 99",
+                                            "body": "수정 내용 99"
+                                        }
+                                        """)
+
+                )
+                .andDo(print());
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1PostsController.class))
+                .andExpect(handler().methodName("updatePost"))
+                .andExpect(jsonPath("$.data.result.id", instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.title", is("수정 제목 99")))
+                .andExpect(jsonPath("$.data.result.body", is("수정 내용 99")))
+                .andExpect(jsonPath("$.data.result.authorId",instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.authorName", notNullValue()))
+                .andExpect(jsonPath("$.data.result.createDate", matchesPattern(DATE_PATTERN)))
+                .andExpect(jsonPath("$.data.result.modifyDate", matchesPattern(DATE_PATTERN)))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("post /api/v1/posts")
+    @WithUserDetails("user57")
+    void t5() throws Exception{
+        //given
+
+        //when
+        ResultActions resultActions = mockMvc
+                .perform(
+                        post("/api/v1/posts")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "title": "new 제목",
+                                            "body": "new 내용"
+                                        }
+                                        """)
+
+                )
+                .andDo(print());
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1PostsController.class))
+                .andExpect(handler().methodName("writePost"))
+                .andExpect(jsonPath("$.data.result.id", instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.title", is("new 제목")))
+                .andExpect(jsonPath("$.data.result.body", is("new 내용")))
+                .andExpect(jsonPath("$.data.result.authorId",instanceOf(Number.class)))
+                .andExpect(jsonPath("$.data.result.authorName", notNullValue()))
+                .andExpect(jsonPath("$.data.result.createDate", matchesPattern(DATE_PATTERN)))
+                .andExpect(jsonPath("$.data.result.modifyDate", matchesPattern(DATE_PATTERN)))
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/com/ll/medium/global/util/jwt/JwtServiceTest.java
+++ b/src/test/java/com/ll/medium/global/util/jwt/JwtServiceTest.java
@@ -1,0 +1,27 @@
+package com.ll.medium.global.util.jwt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+@SpringBootTest
+public class JwtServiceTest {
+    @Autowired
+    private JwtService JwtService;
+    @Test
+    @DisplayName("t1")
+    void t1() {
+        Map<String, Object> map = Map.of(
+                "name", "김효준",
+                "age", "30"
+        );
+        String jwtToken = JwtService.encode(map, 1000 * 60 * 60);
+        System.out.println(jwtToken);
+        assertThat(jwtToken).isNotNull();
+
+    }
+}


### PR DESCRIPTION
* base entity적용

* DTO 적용, 엔드포인트 responsebody적용. 테스트 케이스.

* 테스트 케이스 2, 날짜관련 데이터는 패턴으로 체크

* 테스트 케이스 3, 동적으로 변경

* 테스트 케이스 4, 포스트 단건 조회

* api 통신을 위해 csrf 토큰관련 설정을 따로 해위한 apiSecurityConfig 적용. 테스트 케이스 5, 포스트 단건 삭제

* 테스트 케이스 6, 포스트 단건 수정

* 테스트 케이스 7, 포스트 작성

* RsData 적용.

* RsData 리팩토링

* 모든 api 요청(/api/**)이 처리되기전에 작동하는 필터 JwtAuthenticationFilter 도입

* JwtAuthenticationFilter 에서 가짜 회원생성 후 강제 로그인 처리

* 임시 코드 수정. username 파라미터를 통해서 보낸 사람이 누군지 판단.

* 요청 파라미터로 password를 보내 이전보다는 보안이 나아졌다.

* 요청 헤더로 username과 password를 체크

* apiKey를 통해서 사용자 인증

* 유저가 로그인 할때 apiKey를 발급한다. rq 리팩토링.
api version member controller.
memberDto 적용.

* apiKey 스타일 random으로 변경

* apikey 만료를 통한 모든 기기에서 로그아웃.

* jwt 사융 준비 및 테스트

* member entity에 apikey삭제, 관련 코드 삭제.

* 로그인시 클라이언트에게 줄 accessToken 발급.

* 로그인시 accessToken 발급할때 권한도 함께 인코딩해서 넘겨준다. 토큰 검증시에 권한 정보를 활용해 findById db요청을 줄일수 있다.

* feat : 로그인시 accessToken 발급할때 username과 authorities를 함께 인코딩해서 클라이언트에게 전달

* fix : 클래스 변수 Member -> 유저 id, name, password, authorities로 변경

* refactor : 프록시 객체로 db 조회 안하게

* feat : 토큰 기한 늘리기

* refactor : CustomUser 사용으로 이전에 사용하던 메서드 수정 및 삭제

* feat : token expiration

* feat : jwt refreshToken적용(white list)

* feat : refreshToken 으로 엑세스토큰 재발급

* feat : 프론트 cors 허용

* feat : 사용자에게 accessToke과 refreshToken전달.

* feat : 프론트에서 보낸 accessToken으로 사용자 인증

* feat : 내 글 리스트 생성

* feat : 로그인, 로그아웃 시 엑세스토큰 검사하지 않음

* fix : prod 서버 카카오 로그인을 위한 임시 조치

* fix : prod 서버 카카오 로그인을 위한 임시 조치

* feat : 엑세트 토큰이 만료되면 리프레시 토큰으로 자동으로 갱신